### PR TITLE
Remove ament_python dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,8 +9,6 @@
   <maintainer email="mattanimation@gmail.com">Matt Murray</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>nmea_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>


### PR DESCRIPTION
https://github.com/mattanimation/ros2_berrygps/issues/1

[Test]
**Extant code**
```
habecker@2023-05-08 23:12:02:~$ cd ws/ros2_berrygps/
habecker@2023-05-08 23:12:08:~/ws/ros2_berrygps$ source /opt/ros/humble/setup.bash
habecker@2023-05-08 23:12:16:~/ws/ros2_berrygps$ ls
config  LICENSE      README.md  ros2_berrygps  setup.py
launch  package.xml  resource   setup.cfg      test
habecker@2023-05-08 23:12:18:~/ws/ros2_berrygps$ git status
On branch eloquent
Your branch is up to date with 'origin/eloquent'.
habecker@2023-05-08 23:12:22:~/ws/ros2_berrygps$ colcon build
Starting >>> ros2_berrygps
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
--- stderr: ros2_berrygps
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
---
Finished <<< ros2_berrygps [0.46s]

Summary: 1 package finished [0.56s]
  1 package had stderr output: ros2_berrygps
habecker@2023-05-08 23:12:30:~/ws/ros2_berrygps$ grep ament package.xml 
  <buildtool_depend>ament_python</buildtool_depend>
  <test_depend>ament_copyright</test_depend>
  <test_depend>ament_flake8</test_depend>
  <test_depend>ament_pep257</test_depend>
    <build_type>ament_python</build_type>
```
**Updated code**
```
habecker@2023-05-08 23:13:09:~/ws/ros2_berrygps$ git status
On branch ament_python-dependency-fix
Your branch is up to date with 'origin/ament_python-dependency-fix'.

nothing added to commit but untracked files present (use "git add" to track)
habecker@2023-05-08 23:13:55:~/ws/ros2_berrygps$ colcon build
Starting >>> ros2_berrygps
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
--- stderr: ros2_berrygps
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
---
Finished <<< ros2_berrygps [0.46s]

Summary: 1 package finished [0.55s]
  1 package had stderr output: ros2_berrygps
habecker@2023-05-08 23:14:12:~/ws/ros2_berrygps$ grep ament package.xml 
  <test_depend>ament_copyright</test_depend>
  <test_depend>ament_flake8</test_depend>
  <test_depend>ament_pep257</test_depend>
    <build_type>ament_python</build_type>
```